### PR TITLE
pin monthdelta requirement

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,2 +1,2 @@
 # For calculating month deltas in gregorian systems
-monthdelta
+MonthDelta==1.0b


### PR DESCRIPTION
from monthdelta import MonthDelta
failed with an import error... turned out they changed the class name to CamelCase some time after 0.9.1
